### PR TITLE
L01 - image should not be here at the Start

### DIFF
--- a/01-intro-swiftdata-models-mocks/Starter/GoodDog/GoodDog/Views/EditDogView.swift
+++ b/01-intro-swiftdata-models-mocks/Starter/GoodDog/GoodDog/Views/EditDogView.swift
@@ -51,7 +51,6 @@ struct EditDogView: View {
     || weight != weight
     || color != color
     || breed != breed
-    || image != image
   }
   
   var body: some View {


### PR DESCRIPTION
This "|| image != image" is added near the end of the video. I shouldn't be in the Start code.